### PR TITLE
Initialize a go module file and fix test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/groob/mockimpl
+
+go 1.19
+
+require golang.org/x/tools v0.5.0
+
+require (
+	golang.org/x/mod v0.7.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
+golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=

--- a/impl_test.go
+++ b/impl_test.go
@@ -119,7 +119,7 @@ func TestFuncs(t *testing.T) {
 				},
 				{
 					Name:   "WriteHeader",
-					Params: []Param{{Type: "int"}},
+					Params: []Param{{Type: "int", Name: "statusCode"}},
 				},
 			},
 		},


### PR DESCRIPTION
I run:

```
$ go mod init github.com/groob/mockimpl
$ go mod tidy
```

Using `go v1.19`, I also updated a test, as it seems a parameter name was added to `WriteHeader`