### PR TITLE
Fix output when a package path is provided

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -374,9 +374,14 @@ func main() {
 	name := strings.TrimPrefix(recName[1], "*")
 	src2 := genStr(name, fns)
 
+	_, ifaceID, err := findInterface(iface)
+	if err != nil {
+		fatal(err)
+	}
+
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, packageStr)
-	fmt.Fprintf(&buf, "var _ %s = (*%s)(nil)\n\n", iface, name)
+	fmt.Fprintf(&buf, "var _ %s = (*%s)(nil)\n\n", ifaceID, name)
 	fmt.Fprint(&buf, string(src2))
 	buf.WriteString("\n")
 	fmt.Fprint(&buf, string(src))

--- a/impl.go
+++ b/impl.go
@@ -374,14 +374,14 @@ func main() {
 	name := strings.TrimPrefix(recName[1], "*")
 	src2 := genStr(name, fns)
 
-	_, ifaceID, err := findInterface(iface)
+	path, ifaceID, err := findInterface(iface)
 	if err != nil {
 		fatal(err)
 	}
 
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, packageStr)
-	fmt.Fprintf(&buf, "var _ %s = (*%s)(nil)\n\n", ifaceID, name)
+	fmt.Fprintf(&buf, "var _ %s.%s = (*%s)(nil)\n\n", filepath.Base(path), ifaceID, name)
 	fmt.Fprint(&buf, string(src2))
 	buf.WriteString("\n")
 	fmt.Fprint(&buf, string(src))


### PR DESCRIPTION
Providing a full path to the interface is useful in cases where the interface can't be guessed just from the package name and interface name, however this is not currently accounted for when the output is printed.

This modifies the logic to use the id we get from `findInterface` instead.