### PR TITLE
Fix output for interfaces that use unnamed parameters

### DIFF
--- a/impl.go
+++ b/impl.go
@@ -162,7 +162,7 @@ func (p Pkg) fullType(e ast.Expr) string {
 	return p.gofmt(e)
 }
 
-func (p Pkg) params(field *ast.Field) []Param {
+func (p Pkg) params(field *ast.Field, defaultName string) []Param {
 	var params []Param
 	typ := p.fullType(field.Type)
 	for _, name := range field.Names {
@@ -170,7 +170,7 @@ func (p Pkg) params(field *ast.Field) []Param {
 	}
 	// Handle anonymous params
 	if len(params) == 0 {
-		params = []Param{Param{Type: typ}}
+		params = []Param{Param{Type: typ, Name: defaultName}}
 	}
 	return params
 }
@@ -214,13 +214,14 @@ func (p Pkg) funcsig(f *ast.Field) Func {
 	fn := Func{Name: f.Names[0].Name}
 	typ := f.Type.(*ast.FuncType)
 	if typ.Params != nil {
-		for _, field := range typ.Params.List {
-			fn.Params = append(fn.Params, p.params(field)...)
+		for pos, field := range typ.Params.List {
+			defaultName := fmt.Sprintf("p%d", pos)
+			fn.Params = append(fn.Params, p.params(field, defaultName)...)
 		}
 	}
 	if typ.Results != nil {
 		for _, field := range typ.Results.List {
-			fn.Res = append(fn.Res, p.params(field)...)
+			fn.Res = append(fn.Res, p.params(field, "")...)
 		}
 	}
 	return fn

--- a/impl_test.go
+++ b/impl_test.go
@@ -114,7 +114,7 @@ func TestFuncs(t *testing.T) {
 				},
 				{
 					Name:   "Write",
-					Params: []Param{{Type: "[]byte"}},
+					Params: []Param{{Type: "[]byte", Name: "p0"}},
 					Res:    []Param{{Type: "int"}, {Type: "error"}},
 				},
 				{
@@ -127,8 +127,11 @@ func TestFuncs(t *testing.T) {
 			iface: "http.Handler",
 			want: []Func{
 				{
-					Name:   "ServeHTTP",
-					Params: []Param{{Type: "http.ResponseWriter"}, {Type: "*http.Request"}},
+					Name: "ServeHTTP",
+					Params: []Param{
+						{Name: "p0", Type: "http.ResponseWriter"},
+						{Name: "p1", Type: "*http.Request"},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
If a function contains unnamed parameters, the ouput code is invalid Go code, which causes a panic when the buffer is formatted.

This is because we use the parameter names for the `return` statement of the mock function

For example, for nanomdm's [`RetrievePushInfo`][0] mockimpl is producing an output like this:

```
func (s *NanoMDMStorage) RetrievePushInfo(context.Context, []string) (map[string]*mdm.Push, error) {
	s.RetrievePushInfoFuncInvoked = true
	return s.RetrievePushInfoFunc( , )
}

```

[0]: https://github.com/micromdm/nanomdm/blob/c90f186373b55b6d5ee08e1a0a672532bd3f151e/storage/storage.go#L41